### PR TITLE
Fix health webhook payload usage and add regression test

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -441,9 +441,12 @@ def send_webhook(cfg, payload_text: Optional[str]=None, payload_obj: Optional[di
 # ---------- Health / stats ----------
 def send_health_webhook(cfg, text: str, extra: Optional[dict]=None):
     payload = {"content": text} if cfg.get("webhook_type","discord") == "discord" else {"text": text}
-    if extra: payload.update(extra)
-    try: send_webhook(cfg, payload_text=text)
-    except Exception as e: log(f"[health webhook] failed: {e}")
+    if extra:
+        payload.update(extra)
+    try:
+        send_webhook(cfg, payload_obj=payload)
+    except Exception as e:
+        log(f"[health webhook] failed: {e}")
 
 def summarize_stats_text(level: str, universe_size: int, signals_count: int) -> str:
     dur = None

--- a/tests/test_health_webhook.py
+++ b/tests/test_health_webhook.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch
+import monitor
+
+class TestHealthWebhook(unittest.TestCase):
+    def test_extra_payload_passed(self):
+        cfg = {'webhook_url': 'http://example.com', 'webhook_type': 'discord'}
+        extra = {'foo': 'bar'}
+        with patch('monitor.send_webhook') as mock_send:
+            monitor.send_health_webhook(cfg, 'hello', extra)
+            mock_send.assert_called_once()
+            args, kwargs = mock_send.call_args
+            # first positional arg is cfg
+            self.assertEqual(args[0], cfg)
+            # ensure payload_obj used and includes extra data
+            self.assertIn('payload_obj', kwargs)
+            self.assertEqual(kwargs['payload_obj'], {'content': 'hello', 'foo': 'bar'})
+            # payload_text should not be used
+            self.assertNotIn('payload_text', kwargs)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `send_health_webhook` forwards constructed payload to webhook
- add unit test validating extra fields are included in webhook payload

## Testing
- `python -m py_compile monitor.py summary.py sanity_sim_crosses.py tests/test_health_webhook.py`
- `python -m unittest discover -s tests -p 'test*.py'`


------
https://chatgpt.com/codex/tasks/task_e_68bb9e16e71c8330984404a59fd6fa5c