### PR TITLE
Suppress webhooks outside market hours

### DIFF
--- a/tests/test_health_webhook.py
+++ b/tests/test_health_webhook.py
@@ -1,5 +1,9 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import monitor
 
 class TestHealthWebhook(unittest.TestCase):

--- a/tests/test_market_hours.py
+++ b/tests/test_market_hours.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import monitor
+
+class TestSendWebhookMarketHours(unittest.TestCase):
+    @patch('monitor.requests.post')
+    def test_skip_outside_market_hours(self, mock_post):
+        cfg = {'webhook_url': 'http://example.com', 'webhook_type': 'discord'}
+        with patch('monitor.is_market_hours', return_value=False):
+            monitor.send_webhook(cfg, payload_text='hello')
+        mock_post.assert_not_called()
+
+    @patch('monitor.requests.post')
+    def test_send_during_market_hours(self, mock_post):
+        cfg = {'webhook_url': 'http://example.com', 'webhook_type': 'discord'}
+        with patch('monitor.is_market_hours', return_value=True):
+            monitor.send_webhook(cfg, payload_text='hello')
+        mock_post.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent webhook delivery on weekends and outside 9:30-16:00 ET
- cover webhook timing logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdaca70da083308448786882437416