### PR TITLE
refactor: rename project references in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NYSE EMA Monitor
+# ema-montior
 
-NYSE EMA Monitor is a Python project that scans U.S. equities for 20/50 exponential moving average (EMA) crosses and related trend signals. It retrieves market data from the [Alpaca Markets](https://alpaca.markets/) API, ranks potential setups, and can send alerts via webhooks.
+ema-montior is a Python project that scans U.S. equities for 20/50 exponential moving average (EMA) crosses and related trend signals. It retrieves market data from the [Alpaca Markets](https://alpaca.markets/) API, ranks potential setups, and can send alerts via webhooks.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- rename project to `ema-montior` in README heading and description

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb78719b48330be7cedfda3fb8a20