### PR TITLE
Disable scheduled executions for monitor workflow

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,14 +1,8 @@
 name: NYSE 20/50 EMA Monitor
 
 on:
+  # Disable scheduled runs; workflow can still be triggered manually.
   workflow_dispatch: {}
-  schedule:
-    # Every 15 minutes, 24/7 (UTC)
-    - cron: "*/15 * * * *"
-    # Daily summary at ~23:59 CT (≈ 04:59 UTC)
-    - cron: "59 4 * * *"
-    # Weekly roll-up Sunday 23:59 CT (≈ Monday 04:59 UTC)
-    - cron: "59 4 * * MON"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- remove the cron schedule from the NYSE EMA monitor workflow so it no longer runs automatically
- leave manual workflow_dispatch trigger available for on-demand runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbedfd1f788330ba8ea97fa5498540